### PR TITLE
Range-based identical protein variants

### DIFF
--- a/src/mavehgvs/patterns/protein.py
+++ b/src/mavehgvs/patterns/protein.py
@@ -13,7 +13,9 @@ aa_pos: str = rf"(?:{amino_acid}{pos})"
 """
 
 pro_equal: str = (
-    rf"(?P<pro_equal>(?:(?P<position>{aa_pos})?(?P<equal>=))|(?P<equal_sy>\(=\)))"
+    rf"(?P<pro_equal>(?:(?:(?P<position>{aa_pos})|"
+    + rf"(?:(?P<start>{aa_pos})_(?P<end>{aa_pos})))?(?P<equal>=))|"
+    + rf"(?P<equal_sy>\(=\)))"
 )
 """str: Pattern matching protein equality or synonymous variant.
 """

--- a/src/mavehgvs/variant.py
+++ b/src/mavehgvs/variant.py
@@ -396,19 +396,24 @@ class Variant:
             raise MaveHgvsParseError("variant dictionary missing required keys")
 
         if variant_type == "equal":
-            expected_keys = ["variant_type", "prefix"]
+            expected_keys = ["variant_type", "prefix", "start_position", "end_position"]
             if prefix == "p":
-                expected_keys.extend(["position", "target"])
-            else:
-                expected_keys.extend(["start_position", "end_position"])
+                expected_keys.extend(["start_target", "end_target"])
             if sorted(vdict.keys()) != sorted(expected_keys):
                 raise MaveHgvsParseError("variant dictionary contains invalid keys")
-            if prefix == "p":
-                variant_string = f"{vdict['target']}{vdict['position']}="
-            elif vdict["start_position"] == vdict["end_position"]:
-                variant_string = f"{vdict['start_position']}="
+            if vdict["start_position"] == vdict["end_position"]:
+                if prefix == "p":
+                    if vdict["start_target"] == vdict["end_target"]:
+                        variant_string = f"{vdict['start_target']}{vdict['start_position']}="
+                    else:
+                        raise MaveHgvsParseError("amino acid mismatch at same position")
+                else:
+                    variant_string = f"{vdict['start_position']}="
             else:
-                variant_string = f"{vdict['start_position']}_{vdict['end_position']}="
+                if prefix == "p":
+                    variant_string = f"{vdict['start_target']}{vdict['start_position']}_{vdict['end_target']}{vdict['end_position']}="
+                else:
+                    variant_string = f"{vdict['start_position']}_{vdict['end_position']}="
         elif variant_type == "sub":
             if sorted(vdict.keys()) != sorted(
                 ["variant_type", "prefix", "position", "target", "variant"]

--- a/src/mavehgvs/variant.py
+++ b/src/mavehgvs/variant.py
@@ -396,24 +396,30 @@ class Variant:
             raise MaveHgvsParseError("variant dictionary missing required keys")
 
         if variant_type == "equal":
-            expected_keys = ["variant_type", "prefix", "start_position", "end_position"]
-            if prefix == "p":
-                expected_keys.extend(["start_target", "end_target"])
-            if sorted(vdict.keys()) != sorted(expected_keys):
-                raise MaveHgvsParseError("variant dictionary contains invalid keys")
-            if vdict["start_position"] == vdict["end_position"]:
-                if prefix == "p":
-                    if vdict["start_target"] == vdict["end_target"]:
-                        variant_string = f"{vdict['start_target']}{vdict['start_position']}="
-                    else:
-                        raise MaveHgvsParseError("amino acid mismatch at same position")
-                else:
-                    variant_string = f"{vdict['start_position']}="
+            # special case for fully-identical variants
+            if sorted(vdict.keys()) == ["prefix", "variant_type"]:
+                variant_string = "="
+            elif sorted(vdict.keys()) == ["prefix", "synonymous", "variant_type"] and prefix == "p":
+                variant_string = "(=)"
             else:
+                expected_keys = ["variant_type", "prefix", "start_position", "end_position"]
                 if prefix == "p":
-                    variant_string = f"{vdict['start_target']}{vdict['start_position']}_{vdict['end_target']}{vdict['end_position']}="
+                    expected_keys.extend(["start_target", "end_target"])
+                if sorted(vdict.keys()) != sorted(expected_keys):
+                    raise MaveHgvsParseError("variant dictionary contains invalid keys")
+                if vdict["start_position"] == vdict["end_position"]:
+                    if prefix == "p":
+                        if vdict["start_target"] == vdict["end_target"]:
+                            variant_string = f"{vdict['start_target']}{vdict['start_position']}="
+                        else:
+                            raise MaveHgvsParseError("amino acid mismatch at same position")
+                    else:
+                        variant_string = f"{vdict['start_position']}="
                 else:
-                    variant_string = f"{vdict['start_position']}_{vdict['end_position']}="
+                    if prefix == "p":
+                        variant_string = f"{vdict['start_target']}{vdict['start_position']}_{vdict['end_target']}{vdict['end_position']}="
+                    else:
+                        variant_string = f"{vdict['start_position']}_{vdict['end_position']}="
         elif variant_type == "sub":
             if sorted(vdict.keys()) != sorted(
                 ["variant_type", "prefix", "position", "target", "variant"]

--- a/tests/test_patterns/test_protein.py
+++ b/tests/test_patterns/test_protein.py
@@ -24,6 +24,7 @@ class TestProteinEqual(unittest.TestCase):
             "=",
             "(=)",
             "Cys22=",
+            "Gly12_Glu14=",
         ]
 
         cls.invalid_strings = ["=22", "Arg18(=)", "Cys-22", "=="]

--- a/tests/test_variant.py
+++ b/tests/test_variant.py
@@ -298,6 +298,28 @@ class TestCreateSingleVariantFromValues(unittest.TestCase):
                 {
                     "variant_type": "equal",
                     "prefix": "p",
+                },
+                "p.=",
+            ),
+            (
+                {
+                    "variant_type": "equal",
+                    "prefix": "p",
+                    "synonymous": True,
+                },
+                "p.(=)",
+            ),
+            (
+                {
+                    "variant_type": "equal",
+                    "prefix": "c",
+                },
+                "c.=",
+            ),
+            (
+                {
+                    "variant_type": "equal",
+                    "prefix": "p",
                     "start_position": "27",
                     "start_target": "Glu",
                     "end_position": "27",

--- a/tests/test_variant.py
+++ b/tests/test_variant.py
@@ -80,6 +80,7 @@ class TestCreateSingleVariantFromString(unittest.TestCase):
             "c.12=",
             "g.88_99=",
             "c.43-6_595+12=",
+            "p.Glu12_Gly14=",
         ]
 
         for s in variant_strings:
@@ -229,6 +230,7 @@ class TestCreateMultiVariantFromString(unittest.TestCase):
         invalid_variant_strings = [
             "p.[Glu27Trp;=;Ter345Lys]",
             "p.[(=);Gly18del;Glu27Trp;Ter345Lys]",
+            "p.[Gln7_Asn19=;Glu27Trp;Ter345Lys]",
             "c.[12T>A;=;78+5_78+10del]",
             "c.[1_3=;12T>A;78+5_78+10del]",
             "p.[Glu27fs;Arg48Lys]",
@@ -296,10 +298,23 @@ class TestCreateSingleVariantFromValues(unittest.TestCase):
                 {
                     "variant_type": "equal",
                     "prefix": "p",
-                    "position": "27",
-                    "target": "Glu",
+                    "start_position": "27",
+                    "start_target": "Glu",
+                    "end_position": "27",
+                    "end_target": "Glu",
                 },
                 "p.Glu27=",
+            ),
+            (
+                {
+                    "variant_type": "equal",
+                    "prefix": "p",
+                    "start_position": "12",
+                    "start_target": "Glu",
+                    "end_position": "14",
+                    "end_target": "Gly",
+                },
+                "p.Glu12_Gly14=",
             ),
             (
                 {
@@ -522,6 +537,14 @@ class TestCreateSingleVariantFromValues(unittest.TestCase):
                 "end_position": 50,
                 "end_target": "Cys",
                 "variant": "AlaGly",
+            },
+            {
+                "variant_type": "equal",
+                "prefix": "p",
+                "start_position": "27",
+                "start_target": "Glu",
+                "end_position": "27",
+                "end_target": "Asp",
             },
         ]
 


### PR DESCRIPTION
Adds support for range-bases identical protein variants (e.g. "p.Glu12_Gly14="), which is needed to combine multiple wild-type sequences in cases where each tile has a separate wild-type measurement (e.g. TSC2 meta-analysis).

Also closes https://github.com/VariantEffect/mavehgvs/issues/37